### PR TITLE
HOTFIX: remove refactor branch name prefix and use feat instead of fe…

### DIFF
--- a/.github/workflows/check-branch-name-action.yml
+++ b/.github/workflows/check-branch-name-action.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     type: [opened, reopened]
 
-description: 'Checks the branch name, only branch names that start with refactor/, bugfix/, hotfix/, or feature/ are allowed'
+description: 'Checks the branch name, only branch names that start with bugfix/, hotfix/, or feat/ are allowed'
 
 jobs:
   check-branch-name-is-valid:
@@ -22,7 +22,7 @@ jobs:
         run: |
           BRANCH_NAME="${{ github.head_ref }}"
 
-          if [[ ! $BRANCH_NAME =~ ^(feature|bugfix|hotfix)/[a-z0-9._-]+$ ]]; then
+          if [[ ! $BRANCH_NAME =~ ^(feat|bugfix|hotfix)/[a-z0-9._-]+$ ]]; then
             echo ":( Invalid branch name: $BRANCH_NAME"
             exit 1
           else


### PR DESCRIPTION
This pull request updates the branch name validation logic in the GitHub Actions workflow to align with a new naming convention. Specifically, it replaces the `feature/` prefix with `feat/` in both the description and validation script.

Updates to branch name validation:

* [`.github/workflows/check-branch-name-action.yml`](diffhunk://#diff-0924a1093d075422b29fef17163882e3069dea9de9189b3076ad4ea359ab15edL9-R9): Updated the description to reflect that branch names should now start with `bugfix/`, `hotfix/`, or `feat/` instead of `feature/`.
* [`.github/workflows/check-branch-name-action.yml`](diffhunk://#diff-0924a1093d075422b29fef17163882e3069dea9de9189b3076ad4ea359ab15edL25-R25): Modified the branch name validation regex to accept `feat/` instead of `feature/` as a valid prefix.